### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Since this project was intended to be modular in the importation of devices from
 
 ## Installation
 
-Two options are provided: self-directed installation with requirements OR Docker.  Pick whichever suites your preference, security requirements and deployment capabilities.
+Two options are provided: self-directed installation with requirements OR Docker.  Pick whichever suits your preference, security requirements and deployment capabilities.
 When running as a self-directed installation with requirements, it is suggested to run this project in its own Linux Virtual Machine.  Development was done on CentOS Stream 8.3, but releases at or above the 7 train or other Linux variants should be fine.
 Additionally, Apache and Python environments should be installed - CentOS may have provided one in your installation.  Our guidance is to keep the system-supplied version and install the latest Python and use virtual environments (venv) to maintain separation of environments from the core operating system.  Our development was done on Python v3.9.1, but anything above v3.7 should be sufficient.
  
@@ -89,7 +89,7 @@ Ensure you have a sound password selection for the database user.
 
 ### Docker Installations:
 Ensure you have docker and docker-compose installed in your environment.  In the project's [docker](./docker/) directory is the [docker-compose.yaml](./docker/docker-compose.yaml) file which defines the environment's service requirements.  Essentially, Apache, Python and MySQL images are created.  Remember your first time running 'docker-compose up' will require some time to download images from standard repositories.
-For the docker image we will create two container volumes, web-data and mysql-data, which maintain the dynamic content for the Apache we server and the MySQL database.  They will persist data if 'docker-compose stop' or 'docker-compose down' is executed.  Ensure you monitor the host system's file storage.  Development was done with about 20G disk space and easily manages thousands of endpoint monitors.  
+For the docker image we will create two container volumes, web-data and mysql-data, which maintain the dynamic content for the Apache server and the MySQL database.  They will persist data if 'docker-compose stop' or 'docker-compose down' is executed.  Ensure you monitor the host system's file storage.  Development was done with about 20G disk space and easily manages thousands of endpoint monitors.  
 
 Access the Python container from the host server running docker, with 'docker exec -it dd-cam_python_1 bash'.  The project files are in /project/code.
 
@@ -98,7 +98,7 @@ Access the Python container from the host server running docker, with 'docker ex
 
 An 'optionsconfig.yaml' file defines the Prime Infrastructure, DNA Center and ACI APIC controller IP addresses and authorized API user credentials.  The supplied optionsconfig.yaml file is currently pointing to DevNet Always-On Sandbox systems.  Please note, the devices extracted from those inventories are NOT generally reachable from the public Internet, so your dashboards will have a lot of RED until you reconfigure it to point to EMS/controllers that have access to your network devices.
 
-Edit the [src/optionsconfig.yaml](./src/optionsconfig.yaml) file to suite your environment's inventory sources.  Multiple entries are allowed.  Comment out entries that are not currently used, preserving them for future options.  Enter each server's hostname/IP Address, authorized API username and password and any other parameters of interest.
+Edit the [src/optionsconfig.yaml](./src/optionsconfig.yaml) file to suit your environment's inventory sources.  Multiple entries are allowed.  Comment out entries that are not currently used, preserving them for future options.  Enter each server's hostname/IP Address, authorized API username and password and any other parameters of interest.
 
 
 ## Usage


### PR DESCRIPTION
Installation, paragraph 1: “Pick whichever suites your..” to “suits you”

Linux install steps, step 6: I think you meant to include the link to this DDCAM software? i.e. not just <ORGNAME>/<REPONAME>.git

Docker Installations, towards end of first paragraph: “which maintain the dynamic content for the Apache we server and..” to “Apache server” (remove the word ‘we’)

Configuration, second paragraph: maybe auto complete of ‘suite’ vs ‘suit’ again